### PR TITLE
Updating ruflin/elastica (6.1.1 => 6.1.3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"ruflin/elastica": "6.1.1",
+		"ruflin/elastica": "6.1.3",
 		"ext-curl": "*"
 	},
 	"require-dev": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Elastica",
-	"version": "6.1.1",
+	"version": "6.1.3",
 	"author": [
 		"Nik Everett",
 		"Chad Horohoe"


### PR DESCRIPTION
Bump version to 6.1.3 to match upstream library

Bug: T274877
Change-Id: Ib0d3d307ba1d071df5c6008b6a8efe6353228dbc
Depends-On: I7645f60b154a39a5270e3537251cc62bc9efe6f4